### PR TITLE
Update opencv and change rosrust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ repository = "https://github.com/OmkarKabadagi5823/cv-bridge-rs.git"
 [dependencies]
 byteorder = "1.4.3"
 opencv = "0.95.1"
-rosrust = "0.9.10"
+r2r = "0.9.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cv-bridge"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 authors = ["Omkar Kabadagi <kabadagiomkar@gmail.com>"]
 description = "Rust implemenation of cv_bridge that converts between ROS image messages and OpenCV images"
@@ -13,5 +13,5 @@ repository = "https://github.com/OmkarKabadagi5823/cv-bridge-rs.git"
 
 [dependencies]
 byteorder = "1.4.3"
-opencv = "0.76.4"
+opencv = "0.95.1"
 rosrust = "0.9.10"

--- a/src/cv_image.rs
+++ b/src/cv_image.rs
@@ -2,6 +2,7 @@
 //! CvImage wraps the image array and its metadata and acts as
 //! a bridge between the `sensor_msgs::Image` message and `cv::Mat`
 
+use opencv::boxed_ref::BoxedRef;
 use opencv::prelude::*;
 use std::error::Error;
 
@@ -168,7 +169,7 @@ impl CvImage {
         let src_mat = self.as_cvmat()?;
         let mut dst_mat = Mat::default();
 
-        opencv::imgproc::cvt_color(&src_mat, &mut dst_mat, convertion_code, 0)?;
+        opencv::imgproc::cvt_color(&src_mat, &mut dst_mat, convertion_code, 0, opencv::core::AlgorithmHint::ALGO_HINT_DEFAULT)?;
 
         let cvtype = image_encodings::from_encstr_to_cvtype(desired_encoding)?;
         let scaling = image_encodings::get_scaling_factor(&self.encoding, desired_encoding);
@@ -187,7 +188,7 @@ impl CvImage {
     /// * `opencv::core::Mat` object
     pub fn as_cvmat(&mut self) -> Result<Mat, Box<dyn Error>> {
         let cvtype = image_encodings::from_encstr_to_cvtype(&self.encoding)?;
-        
+
         let buffer_mut_ptr = match self.data {
             DataContainer::VecU8(ref mut data) => data.as_mut_ptr() as *mut _,
             DataContainer::VecU16(ref mut data) => data.as_mut_ptr() as *mut _,
@@ -196,7 +197,7 @@ impl CvImage {
 
         let mat;
         unsafe {
-            mat = Mat::new_rows_cols_with_data(
+            mat = Mat::new_rows_cols_with_data_unsafe(
                 self.height as i32,
                 self.width as i32,
                 cvtype,

--- a/src/cv_image.rs
+++ b/src/cv_image.rs
@@ -2,13 +2,12 @@
 //! CvImage wraps the image array and its metadata and acts as
 //! a bridge between the `sensor_msgs::Image` message and `cv::Mat`
 
-use opencv::boxed_ref::BoxedRef;
 use opencv::prelude::*;
 use std::error::Error;
 
-use crate::msgs::{
-    std_msgs::Header,
-    sensor_msgs::Image,
+use r2r::{
+    std_msgs::msg::Header,
+    sensor_msgs::msg::Image,
 };
 use crate::utils::{
     image_encodings,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,6 @@
 //! }
 //! ```
 
-pub mod msgs;
 pub mod cv_image;
 pub mod utils;
 

--- a/src/msgs.rs
+++ b/src/msgs.rs
@@ -1,8 +1,0 @@
-//! Manually generated ros messages
-
-rosrust::rosmsg_include!(
-    std_msgs / Header,
-    sensor_msgs / CameraInfo,
-    sensor_msgs / Image,
-    sensor_msgs / CompressedImage,
-);


### PR DESCRIPTION
- **update: opencv=0.95.1**
- **Change rosrust to r2r**

Update OpenCV, I mostly did minimal changes to make the build work. Ideally we should use the safe versions of the functions,
but I could not find a way toto send the correct cvtype that way.

Also, rosrust has not been updated in the crate since 2020, while r2r is still actively maintained. The struct is the exact same
though (after all they're implementations of the same thing) so only minimal changes were needed too.
